### PR TITLE
adds passwd-init script

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,3 +1,7 @@
 - include: baseline.yml
   tags:
     - baseline
+
+- include: passwd-init.yml
+  tags:
+    - baseline

--- a/tasks/passwd-init.yml
+++ b/tasks/passwd-init.yml
@@ -1,0 +1,15 @@
+- name: Install passwd-init script
+  template:
+    src: passwd-init.j2
+    dest: /usr/local/sbin/passwd-init
+    mode: 0755
+    group: root
+    owner: root
+
+- name: install sudoers config to run passwd-init without password
+  template:
+    src: 20-passwd-init.j2
+    dest: /etc/sudoers.d/20-passwd-init
+    mode: 0440
+    group: root
+    owner: root

--- a/templates/20-passwd-init.j2
+++ b/templates/20-passwd-init.j2
@@ -1,0 +1,1 @@
+%sudo ALL=(ALL:ALL) NOPASSWD: /usr/local/sbin/passwd-init

--- a/templates/passwd-init.j2
+++ b/templates/passwd-init.j2
@@ -1,0 +1,20 @@
+#! /bin/sh
+
+PATH=/usr/bin
+
+if [ -z "$SUDO_USER" ]; then
+    echo "Not in a sudo environment ! Aborting."
+    exit 1
+fi
+
+if [ "$(id -u)" != "0" ]; then
+    echo "This script must be executed as root ! Aborting."
+    exit 1
+fi
+
+if [ "$(passwd -S "$SUDO_USER" | cut -d' ' -f2)" != "L" ]; then
+    echo "The user password for '$SUDO_USER' exist already."
+    exit 1
+fi
+
+passwd "$SUDO_USER"


### PR DESCRIPTION
Ajout d'un script permettant aux baseline_users n'ayant pas de mot de passe défini ET membre du groupe sudo d'initialiser leur mot de passe en executant le script /usr/local/sbin/passwd-init