### PR TITLE
adds ncdu to baseline packages

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -19,3 +19,4 @@ baseline_packages:
     - bmon
     - iptraf
     - language-pack-fr-base
+    - ncdu


### PR DESCRIPTION
Ajout de `ncdu` [ref] aux baseline packages. Outil pratique pour trouver rapidement les fichiers volumineux sur un FS.

[ref]: https://dev.yorhel.nl/ncdu