### PR TITLE
adds unattended upgrade in baseline role with only security upgrade & no reboot

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,3 +14,21 @@ baseline_file_limit: 500000
 
 iftop_default_interface: "{{ ansible_interfaces.1 }}"
 
+# Unattended upgrades
+## general config used in uu_config.j2
+
+uu_system_packages:
+  - unattended-upgrades
+
+uu_reboot: false
+uu_send_email: true
+uu_email_to: root
+uu_email_on_error_only: false
+
+## Scheduling Controls
+### used in uu_periodic.j2
+
+uu_update_package_lists: 1
+uu_download_upgradeable_packages: 1
+uu_autoclean_interval: 7
+uu_unattended_upgrade: 1

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,3 +5,9 @@
 - include: passwd-init.yml
   tags:
     - baseline
+
+- include: unattended-upgrades.yml
+  tags:
+    - baseline
+    - unattendedupgrades
+    - uu

--- a/tasks/unattended-upgrades.yml
+++ b/tasks/unattended-upgrades.yml
@@ -1,0 +1,19 @@
+- name: Upgrade System Packages
+  apt: force=yes update_cache=yes upgrade=yes
+  register: uu_system_updated
+
+- name: Install System Packages
+  when: uu_system_updated is success
+  apt: pkg={{ item }} state=present force=yes
+  with_items: "{{ uu_system_packages }}"
+
+- name: Place unattended upgrades config files
+  template: >
+    src={{ item.src }}
+    dest={{ item.dest }}
+    owner=root
+    group=root
+    mode=0600
+  with_items:
+    - { src: uu_config.j2, dest: /etc/apt/apt.conf.d/50unattended-upgrades }
+    - { src: uu_periodic.j2, dest: /etc/apt/apt.conf.d/02periodic }

--- a/templates/uu_config.j2
+++ b/templates/uu_config.j2
@@ -1,0 +1,61 @@
+// Automatically upgrade packages from these (origin:archive) pairs
+Unattended-Upgrade::Allowed-Origins {
+        "${distro_id}:${distro_codename}-security";
+//      "${distro_id}:${distro_codename}-updates";
+//      "${distro_id}:${distro_codename}-proposed";
+//      "${distro_id}:${distro_codename}-backports";
+};
+
+// List of packages to not update (regexp are supported)
+Unattended-Upgrade::Package-Blacklist {
+//      "vim";
+};
+
+// This option allows you to control if on a unclean dpkg exit
+// unattended_updates-upgrades will automatically run
+//   dpkg --force-confold --configure -a
+// The default is true, to ensure updates keep getting installed
+//Unattended-Upgrade::AutoFixInterruptedDpkg "false";
+
+// Split the upgrade into the smallest possible chunks so that
+// they can be interrupted with SIGUSR1. This makes the upgrade
+// a bit slower but it has the benefit that shutdown while a upgrade
+// is running is possible (with a small delay)
+//Unattended-Upgrade::MinimalSteps "true";
+
+// Install all unattended_updates-upgrades when the machine is shuting down
+// instead of doing it in the background while the machine is running
+// This will (obviously) make shutdown slower
+//Unattended-Upgrade::InstallOnShutdown "true";
+
+// Send email to this address for problems or packages upgrades
+// If empty or unset then no email is sent, make sure that you
+// have a working mail setup on your system. A package that provides
+// 'mailx' must be installed. E.g. "user@example.com"
+
+{% if uu_send_email == true %}
+Unattended-Upgrade::Mail "{{ uu_email_to|default('root') }}";
+{% else %}
+// Unattended-Upgrade::Mail "root";
+{% endif %}
+
+// Set this value to "true" to get emails only on errors. Default
+// is to always send a mail if Unattended-Upgrade::Mail is set
+Unattended-Upgrade::MailOnlyOnError "{{ uu_email_on_error_only|default('false')|lower() }}";
+
+// Do automatic removal of new unused dependencies after the upgrade
+// (equivalent to apt-get autoremove)
+Unattended-Upgrade::Remove-Unused-Dependencies "true";
+
+// Automatically reboot *WITHOUT CONFIRMATION*
+//  if the file /var/run/reboot-required is found after the upgrade
+Unattended-Upgrade::Automatic-Reboot "{{ uu_reboot|default('false')|lower() }}";
+
+// If automatic reboot is enabled and needed, reboot at the specific
+// time instead of immediately
+//  Default: "now"
+//Unattended-Upgrade::Automatic-Reboot-Time "02:00";
+
+// Use apt bandwidth limit feature, this example limits the download
+// speed to 70kb/sec
+//Acquire::http::Dl-Limit "70";

--- a/templates/uu_periodic.j2
+++ b/templates/uu_periodic.j2
@@ -1,0 +1,4 @@
+APT::Periodic::Update-Package-Lists "{{ uu_update_package_lists|default('1') }}";
+APT::Periodic::Download-Upgradeable-Packages "{{ uu_download_upgradeable_packages|default('1') }}";
+APT::Periodic::AutocleanInterval "{{ uu_autoclean_interval|default('7') }}";
+APT::Periodic::Unattended-Upgrade "{{ uu_unattended_upgrade|default('1') }}";


### PR DESCRIPTION
Defaults vars :
```
uu_system_packages:
  - unattended-upgrades

uu_reboot: false
uu_send_email: true
uu_email_to: root
uu_email_on_error_only: false
uu_update_package_lists: 1
uu_download_upgradeable_packages: 1
uu_autoclean_interval: 7
uu_unattended_upgrade: 1
```